### PR TITLE
Fix : changed code references to be on main branch instead of feature…

### DIFF
--- a/templates/cloud-app/coderef.json
+++ b/templates/cloud-app/coderef.json
@@ -1,5 +1,5 @@
 {
     "url": "https://github.com/Mentoring-Bordeaux/nebulift.git",
     "path": "templates/cloud-app",
-    "branch": "feature/template-execution"
+    "branch": "main"
 }

--- a/templates/poc-options/coderef.json
+++ b/templates/poc-options/coderef.json
@@ -1,5 +1,5 @@
 {
     "url": "https://github.com/Mentoring-Bordeaux/nebulift.git",
     "path": "templates/poc-options",
-    "branch": "feature/template-execution"
+    "branch": "main"
 }

--- a/templates/static-hosting/coderef.json
+++ b/templates/static-hosting/coderef.json
@@ -1,5 +1,5 @@
 {
     "url": "https://github.com/Mentoring-Bordeaux/nebulift.git",
     "path": "templates/static-hosting",
-    "branch": "feature/template-execution"
+    "branch": "main"
 }


### PR DESCRIPTION
The templates contain a coderef.json file that has a reference to this repository on a certain branch to get the source code / pulumi code for the template.

This PR simply changes the code refs in the templates to the main branch instead of the template execution branch because we couldn't have main before (the templates weren't up to date in main).